### PR TITLE
Rename my-whisper to pr-whisper to match repo name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-my-whisper is an Emacs package providing speech-to-text functionality using whisper.cpp. It records audio via sox,
+pr-whisper is an Emacs package providing speech-to-text functionality using whisper.cpp. It records audio via sox,
 transcribes using Whisper models, and inserts text at the cursor position.
 
 ## Build & Lint
@@ -16,14 +16,14 @@ Byte-compile with warnings as errors:
 
 Or manually:
 ```bash
-emacs -Q --batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile my-whisper.el
+emacs -Q --batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile pr-whisper.el
 ```
 
 ## Architecture
 
-Single-file Emacs Lisp package (`my-whisper.el`) with these key components:
+Single-file Emacs Lisp package (`pr-whisper.el`) with these key components:
 
-- **`my-whisper-mode`**: Global minor mode that enables recording controls (C-c . to toggle)
+- **`pr-whisper-mode`**: Global minor mode that enables recording controls (C-c . to toggle)
 - **Recording**: Uses sox to record 16kHz mono 16-bit WAV files to `/tmp/whisper-recording-<pid>.wav`
 - **Transcription**: Async process calling `whisper-cli` with process sentinel for completion handling
 - **Vocabulary hints**: Optional `--prompt` argument passed to whisper-cli for better recognition of proper nouns
@@ -31,25 +31,25 @@ Single-file Emacs Lisp package (`my-whisper.el`) with these key components:
 
 ### Key Functions
 
-- `my-whisper-toggle-recording`: Start/stop recording (bound to C-c . in mode)
-- `my-whisper-record-audio`: Starts sox recording process
-- `my-whisper-stop-record`: Interrupts recording, triggers transcription
-- `my-whisper--transcribe`: Async whisper-cli call with sentinel that inserts output at marker position
-- `my-whisper--validate-environment`: Checks sox, whisper-cli, and model paths before operations
-- `my-whisper-transcribe-file`: Transcribes an existing WAV file without recording
-- `my-whisper-insert-from-history`: Browse and re-insert previous transcriptions
+- `pr-whisper-toggle-recording`: Start/stop recording (bound to C-c . in mode)
+- `pr-whisper-record-audio`: Starts sox recording process
+- `pr-whisper-stop-record`: Interrupts recording, triggers transcription
+- `pr-whisper--transcribe`: Async whisper-cli call with sentinel that inserts output at marker position
+- `pr-whisper--validate-environment`: Checks sox, whisper-cli, and model paths before operations
+- `pr-whisper-transcribe-file`: Transcribes an existing WAV file without recording
+- `pr-whisper-insert-from-history`: Browse and re-insert previous transcriptions
 
 ### Customization Variables
 
-- `my-whisper-homedir`: whisper.cpp installation directory (default: `~/whisper.cpp/`)
-- `my-whisper-model`: Model file name (e.g., `ggml-medium.en.bin`)
-- `my-whisper-vocabulary-file`: Path to vocabulary hints file
-- `my-whisper-sox`: sox executable path
-- `my-whisper-key-for-toggle`: Key binding for toggle (default: `C-c .`)
-- `my-whisper-history-capacity`: Max transcriptions in history ring (default: 20)
+- `pr-whisper-homedir`: whisper.cpp installation directory (default: `~/whisper.cpp/`)
+- `pr-whisper-model`: Model file name (e.g., `ggml-medium.en.bin`)
+- `pr-whisper-vocabulary-file`: Path to vocabulary hints file
+- `pr-whisper-sox`: sox executable path
+- `pr-whisper-key-for-toggle`: Key binding for toggle (default: `C-c .`)
+- `pr-whisper-history-capacity`: Max transcriptions in history ring (default: 20)
 
 ## External Dependencies
 
 - **sox**: Audio recording (`sox -d -r 16000 -c 1 -b 16 output.wav`)
-- **whisper.cpp**: Located at `my-whisper-homedir/build/bin/whisper-cli`
-- **Models**: Located at `my-whisper-homedir/models/<model-name>`
+- **whisper.cpp**: Located at `pr-whisper-homedir/build/bin/whisper-cli`
+- **Models**: Located at `pr-whisper-homedir/models/<model-name>`

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# My Whisper - Speech-to-Text for Emacs - My enhanced fork.
+# Pr-Whisper - Speech-to-Text for Emacs
 
 A simple Emacs package that provides speech-to-text functionality using Whisper.cpp.
 
 Record audio directly from Emacs and have it transcribed and inserted in current buffer at point.
-The package provides `my-whisper-mode`, a global minor mode that starts audio recording and transcribes text when stopped.
-It also provides the `my-whisper-transcribe-file` command to transcribe an already recorded WAV audio file.
+The package provides `pr-whisper-mode`, a global minor mode that starts audio recording and transcribes text when stopped.
+It also provides the `pr-whisper-transcribe-file` command to transcribe an already recorded WAV audio file.
 
 I will eventually change this page in my fork.  This is under construction.
 
@@ -26,7 +26,7 @@ in my PEL project inside the [Writing Tools PDF](https://raw.githubusercontent.c
 - **Model selection**: Choose from multiple Whisper models via customization
 - **Vocabulary hints**: Provide a custom vocabulary file to improve recognition of proper nouns and specialized
   terms (e.g., Greek names like Socrates, Alcibiades, Diotima)
-- **Transcription history**: Browse and re-insert previous transcriptions with `M-x my-whisper-insert-from-history`
+- **Transcription history**: Browse and re-insert previous transcriptions with `M-x pr-whisper-insert-from-history`
 - Automatic transcription using Whisper.cpp
 - Text insertion at cursor position
 - Async processing - Emacs remains responsive during transcription
@@ -75,20 +75,20 @@ bash ./models/download-ggml-model.sh medium.en
 ## Usage
 
 
-This provides the **my-whisper-mode**, a global minor mode that provides the ability to record audio and then process it with whisper.cpp and insert transcribed text in the current buffer at point.
+This provides the **pr-whisper-mode**, a global minor mode that provides the ability to record audio and then process it with whisper.cpp and insert transcribed text in the current buffer at point.
 
 ⚠️  🚧 🚧 🚧 Most of the text below is obsolete and needs to be updated.
 
 ### Key Bindings
 
-- **`M-x my-whisper-mode`**: Enable the global minor mode (does not start recording).
+- **`M-x pr-whisper-mode`**: Enable the global minor mode (does not start recording).
 - **`C-c .`**: Toggle recording on/off. When stopped, transcribes and inserts text at point.
-- **`M-x my-whisper-mode`**: Disable the mode (stops any active recording).
+- **`M-x pr-whisper-mode`**: Disable the mode (stops any active recording).
 
 
 ### Basic Workflow
 
-1. **Enable mode**: `M-x my-whisper-mode`
+1. **Enable mode**: `M-x pr-whisper-mode`
 2. **Start recording**: Press `C-c .`
 3. **Stop and transcribe**: Press `C-c .` again
 4. **Get results**: The transcribed text is automatically inserted at your cursor position
@@ -96,7 +96,7 @@ This provides the **my-whisper-mode**, a global minor mode that provides the abi
 ### Example
 
 1. Open any text buffer in Emacs
-2. Enable the mode: `M-x my-whisper-mode`
+2. Enable the mode: `M-x pr-whisper-mode`
 3. Position your cursor where you want the transcribed text
 4. Press `C-c .` to start recording
 5. Speak into your microphone
@@ -106,39 +106,39 @@ This provides the **my-whisper-mode**, a global minor mode that provides the abi
 
 ## Configuration
 
-You can customize my-whisper through Emacs' built-in customization interface or directly in your `init.el`.
+You can customize pr-whisper through Emacs' built-in customization interface or directly in your `init.el`.
 
 ### Using Emacs Customize Interface
 
-Run `M-x customize-group RET my-whisper RET` to access all customization options:
+Run `M-x customize-group RET pr-whisper RET` to access all customization options:
 
-- **my-whisper-homedir**: Directory where Whisper.cpp is installed (default: `~/whisper.cpp/`)
-- **my-whisper-model**: Which model to use by default
+- **pr-whisper-homedir**: Directory where Whisper.cpp is installed (default: `~/whisper.cpp/`)
+- **pr-whisper-model**: Which model to use by default
   - `ggml-base.en.bin` - Fast mode (quick, good accuracy)
   - `ggml-medium.en.bin` - Accurate mode (slower, better accuracy)
   - Custom model filename
-- **my-whisper-vocabulary-file**: Path to vocabulary hints file (default: `~/.emacs.d/whisper-vocabulary.txt`)
+- **pr-whisper-vocabulary-file**: Path to vocabulary hints file (default: `~/.emacs.d/whisper-vocabulary.txt`)
 
 ### Custom Configuration in init.el
 
 ```elisp
 ;; Set custom Whisper.cpp installation directory
-(setq my-whisper-homedir "/usr/local/whisper.cpp/")
+(setq pr-whisper-homedir "/usr/local/whisper.cpp/")
 
 ;; Choose default model (base.en or medium.en)
-(setq my-whisper-model "ggml-medium.en.bin")
+(setq pr-whisper-model "ggml-medium.en.bin")
 
 ;; Set custom vocabulary file location
-(setq my-whisper-vocabulary-file "~/Documents/my-vocabulary.txt")
+(setq pr-whisper-vocabulary-file "~/Documents/vocabulary.txt")
 ```
 
 ### Custom Key Bindings
 
-To change the toggle key binding, customize `my-whisper-key-for-toggle` or set it before loading:
+To change the toggle key binding, customize `pr-whisper-key-for-toggle` or set it before loading:
 
 ```elisp
 ;; Use a different key binding for toggle
-(setq my-whisper-key-for-toggle (kbd "C-c s"))
+(setq pr-whisper-key-for-toggle (kbd "C-c s"))
 ```
 
 ### Custom Vocabulary for Proper Nouns
@@ -152,7 +152,7 @@ This transcription discusses classical Greek philosophy, including scholars and 
 
 **Custom vocabulary location:**
 ```elisp
-(setq my-whisper-vocabulary-file "~/Documents/my-vocabulary.txt")
+(setq pr-whisper-vocabulary-file "~/Documents/vocabulary.txt")
 ```
 
 **For detailed guidance** on vocabulary formats, tips, domain-specific examples, and managing multiple vocabularies, see [VOCABULARY-GUIDE.md](VOCABULARY-GUIDE.md).
@@ -167,8 +167,8 @@ This transcription discusses classical Greek philosophy, including scholars and 
 2. **"whisper-cli: command not found" or path errors**
    - Ensure Whisper.cpp is built and the path is correct
    - Check that `~/whisper.cpp/build/bin/whisper-cli` exists
-   - If installed elsewhere, customize `my-whisper-homedir` to match your installation
-   - Run `M-x customize-group RET my-whisper RET` to verify paths
+   - If installed elsewhere, customize `pr-whisper-homedir` to match your installation
+   - Run `M-x customize-group RET pr-whisper RET` to verify paths
 
 3. **No audio recorded**
    - Check your microphone permissions
@@ -177,7 +177,7 @@ This transcription discusses classical Greek philosophy, including scholars and 
 4. **Transcription not working**
    - The package now validates paths on startup and will show clear error messages
    - Verify the model files exist in `~/whisper.cpp/models/`
-   - Run `M-x my-whisper-transcribe-fast` to see validation errors
+   - Run `M-x pr-whisper-transcribe-fast` to see validation errors
    - Test whisper-cli manually with a wav file
 
 ### Testing the Setup

--- a/VOCABULARY-GUIDE.md
+++ b/VOCABULARY-GUIDE.md
@@ -10,7 +10,7 @@ Default: `~/.emacs.d/whisper-vocabulary.txt`
 
 To use a different location, add to your `init.el`:
 ```elisp
-(setq whisper-vocabulary-file "/path/to/your/vocabulary.txt")
+(setq pr-whisper-vocabulary-file "/path/to/your/vocabulary.txt")
 ```
 
 ## Format
@@ -71,18 +71,18 @@ For different subjects, create separate vocabulary files:
 
 ```elisp
 ;; In your init.el
-(defun my-use-symposium-vocab ()
+(defun use-symposium-vocab ()
   (interactive)
-  (setq whisper-vocabulary-file "~/Documents/symposium-vocab.txt")
+  (setq pr-whisper-vocabulary-file "~/Documents/symposium-vocab.txt")
   (message "Using Symposium vocabulary"))
 
-(defun my-use-republic-vocab ()
+(defun use-republic-vocab ()
   (interactive)
-  (setq whisper-vocabulary-file "~/Documents/republic-vocab.txt")
+  (setq pr-whisper-vocabulary-file "~/Documents/republic-vocab.txt")
   (message "Using Republic vocabulary"))
 ```
 
-Then switch vocabularies as needed with `M-x my-use-symposium-vocab`.
+Then switch vocabularies as needed with `M-x use-symposium-vocab`.
 
 ## Troubleshooting
 

--- a/build
+++ b/build
@@ -23,6 +23,6 @@
 #
 
 set -x
-emacs -Q  --batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile my-whisper.el
+emacs -Q  --batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile pr-whisper.el
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Rename package from `my-whisper` to `pr-whisper` to match repository name
- Update all function/variable prefixes from `my-` to `pr-`
- Update documentation (README.md, CLAUDE.md, VOCABULARY-GUIDE.md)
- Fix vocabulary file docstring to accurately describe supported formats

## Test plan

- [x] Tested byte-compilation with `./build` - passes with no warnings
- [x] Tested installation via elpaca locally - works well
