### PR TITLE
Use gptel-with-preset for per-request model override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled
 *.elc
+llama.cpp
 
 # Packaging
 .cask/

--- a/pr-whisper-reflow.el
+++ b/pr-whisper-reflow.el
@@ -2,6 +2,7 @@
 
 ;;; Commentary:
 ;; Use gptel to reflow whisper transcriptions into logical paragraphs.
+;; Requires gptel >= 0.9.8.5 (for `gptel-with-preset').
 ;;
 ;; Why not a local model? Reflowing requires understanding enough English
 ;; context to identify sentence boundaries, topic transitions, and spoken

--- a/pr-whisper-reflow.el
+++ b/pr-whisper-reflow.el
@@ -18,6 +18,7 @@
 
 (defvar gptel-model)
 (declare-function gptel-request "gptel")
+(declare-function gptel-with-preset "gptel")
 (declare-function pr-whisper-default-insert "pr-whisper")
 (defvar pr-whisper-reflow-prompt
   "Reflow this transcription into logical paragraphs. Rules:
@@ -59,7 +60,7 @@ Reflows TEXT via LLM and inserts at MARKER when complete.
 Calls `pr-whisper-reflow-predicate' to decide whether to reflow;
 otherwise uses default insertion."
   (if (funcall pr-whisper-reflow-predicate text marker)
-      (let ((gptel-model pr-whisper-reflow-model))
+      (gptel-with-preset `(:model ,pr-whisper-reflow-model)
         (message "Reflowing transcription...")
         (gptel-request
          (format pr-whisper-reflow-prompt text)

--- a/pr-whisper-reflow.el
+++ b/pr-whisper-reflow.el
@@ -17,9 +17,9 @@
 
 ;;; Code:
 
+(eval-when-compile (require 'gptel))
 (defvar gptel-model)
 (declare-function gptel-request "gptel")
-(declare-function gptel-with-preset "gptel")
 (declare-function pr-whisper-default-insert "pr-whisper")
 (defvar pr-whisper-reflow-prompt
   "Reflow this transcription into logical paragraphs. Rules:

--- a/pr-whisper-reflow.el
+++ b/pr-whisper-reflow.el
@@ -61,15 +61,16 @@ Reflows TEXT via LLM and inserts at MARKER when complete.
 Calls `pr-whisper-reflow-predicate' to decide whether to reflow;
 otherwise uses default insertion."
   (if (funcall pr-whisper-reflow-predicate text marker)
-      (gptel-with-preset `(:model ,pr-whisper-reflow-model)
-        (message "Reflowing transcription...")
-        (gptel-request
-         (format pr-whisper-reflow-prompt text)
-         :callback (lambda (response _info)
-                     (pr-whisper-default-insert
-                      (if response (string-trim response) text)
-                      marker)
-                     (message "Reflow complete."))))
+      (let ((default-directory temporary-file-directory))
+        (gptel-with-preset `(:model ,pr-whisper-reflow-model)
+          (message "Reflowing transcription...")
+          (gptel-request
+           (format pr-whisper-reflow-prompt text)
+           :callback (lambda (response _info)
+                       (pr-whisper-default-insert
+                        (if response (string-trim response) text)
+                        marker)
+                       (message "Reflow complete.")))))
     (pr-whisper-default-insert text marker)))
 
 (provide 'pr-whisper-reflow)

--- a/pr-whisper-reflow.el
+++ b/pr-whisper-reflow.el
@@ -33,10 +33,17 @@ Transcription:
   "Prompt template for reflowing transcriptions.
 %s is replaced with the transcription text.")
 
-(defcustom pr-whisper-reflow-model "gemini-2.5-flash-lite"
-  "Model to use for reflow.
-Examples: \"gemini-2.0-flash-lite\", \"qwen2.5:1.5b\" (Ollama)."
+(defcustom pr-whisper-reflow-backend "Gemini"
+  "gptel backend name for reflow.
+Must match a backend registered with gptel (e.g. \"Gemini\",
+\"ChatGPT\", \"Claude\")."
   :type 'string
+  :group 'pr-whisper)
+
+(defcustom pr-whisper-reflow-model 'gemini-2.5-flash-lite
+  "Model to use for reflow.
+Must be a symbol matching a model in `pr-whisper-reflow-backend'."
+  :type 'symbol
   :group 'pr-whisper)
 
 (defcustom pr-whisper-reflow-min-length 100
@@ -62,7 +69,8 @@ Calls `pr-whisper-reflow-predicate' to decide whether to reflow;
 otherwise uses default insertion."
   (if (funcall pr-whisper-reflow-predicate text marker)
       (let ((default-directory temporary-file-directory))
-        (gptel-with-preset `(:model ,pr-whisper-reflow-model)
+        (gptel-with-preset `(:backend ,pr-whisper-reflow-backend
+                            :model ,pr-whisper-reflow-model)
           (message "Reflowing transcription...")
           (gptel-request
            (format pr-whisper-reflow-prompt text)

--- a/pr-whisper-reflow.el
+++ b/pr-whisper-reflow.el
@@ -1,8 +1,11 @@
 ;;; pr-whisper-reflow.el --- Reflow transcriptions using LLM -*- lexical-binding: t -*-
 
+;; Package-Requires: ((emacs "25.1") (gptel "0.9.9"))
+
 ;;; Commentary:
 ;; Use gptel to reflow whisper transcriptions into logical paragraphs.
-;; Requires gptel >= 0.9.8.5 (for `gptel-with-preset').
+;; Requires gptel >= 0.9.9 (for inline preset specs in
+;; `gptel-with-preset').
 ;;
 ;; Why not a local model? Reflowing requires understanding enough English
 ;; context to identify sentence boundaries, topic transitions, and spoken
@@ -17,11 +20,10 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'gptel))
-(defvar gptel-model)
-(declare-function gptel-request "gptel")
+(require 'gptel)
 (declare-function pr-whisper-default-insert "pr-whisper")
-(defvar pr-whisper-reflow-prompt
+
+(defcustom pr-whisper-reflow-prompt
   "Reflow this transcription into logical paragraphs. Rules:
 1. Replace spoken commands like \"new paragraph\", \"new line\" with actual line breaks
 2. Add paragraph breaks at natural topic transitions
@@ -31,7 +33,9 @@
 Transcription:
 %s"
   "Prompt template for reflowing transcriptions.
-%s is replaced with the transcription text.")
+%s is replaced with the transcription text."
+  :type 'string
+  :group 'pr-whisper)
 
 (defcustom pr-whisper-reflow-backend "Gemini"
   "gptel backend name for reflow.
@@ -42,7 +46,9 @@ Must match a backend registered with gptel (e.g. \"Gemini\",
 
 (defcustom pr-whisper-reflow-model 'gemini-2.5-flash-lite
   "Model to use for reflow.
-Must be a symbol matching a model in `pr-whisper-reflow-backend'."
+Must be a symbol matching a model in `pr-whisper-reflow-backend'.
+List available models with:
+  (gptel-backend-models (gptel-get-backend pr-whisper-reflow-backend))"
   :type 'symbol
   :group 'pr-whisper)
 
@@ -68,6 +74,8 @@ Reflows TEXT via LLM and inserts at MARKER when complete.
 Calls `pr-whisper-reflow-predicate' to decide whether to reflow;
 otherwise uses default insertion."
   (if (funcall pr-whisper-reflow-predicate text marker)
+      ;; The buffer's default-directory may no longer exist (e.g. a
+      ;; deleted temp dir), which breaks process invocation in gptel.
       (let ((default-directory temporary-file-directory))
         (gptel-with-preset `(:backend ,pr-whisper-reflow-backend
                             :model ,pr-whisper-reflow-model)
@@ -75,10 +83,13 @@ otherwise uses default insertion."
           (gptel-request
            (format pr-whisper-reflow-prompt text)
            :callback (lambda (response _info)
-                       (pr-whisper-default-insert
-                        (if response (string-trim response) text)
-                        marker)
-                       (message "Reflow complete.")))))
+                       (if (stringp response)
+                           (progn
+                             (pr-whisper-default-insert
+                              (string-trim response) marker)
+                             (message "Reflow complete."))
+                         (pr-whisper-default-insert text marker)
+                         (message "Reflow failed; inserted original transcription."))))))
     (pr-whisper-default-insert text marker)))
 
 (provide 'pr-whisper-reflow)


### PR DESCRIPTION
## Summary

- Use `gptel-with-preset` instead of `let`-binding `gptel-model` in reflow, eliminating the
  "Making gptel-model buffer-local while locally let-bound!" warning
- Update .gitignore

## Test plan

- `./build` passes (byte-compile with warnings-as-errors)
- ERT tests pass (13/13)
- Reflow transcription in Emacs — no warning in `*Messages*`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ignore a compiled runtime artifact.

* **Refactor**
  * Reflow now runs from a temporary working directory and uses a preset-based model invocation for more consistent behavior while preserving insertion flow.

* **New Features**
  * Added configurable backend, model, and minimum-length options for the reflow operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->