### PR TITLE
Add ghostel support to default insert

### DIFF
--- a/pr-whisper.el
+++ b/pr-whisper.el
@@ -59,6 +59,7 @@
 
 (require 'ring)
 (declare-function vterm-send-string "vterm")
+(declare-function ghostel-send-string "ghostel")
 
 ;; Server backend autoloads - loaded on demand when pr-whisper-backend is 'server
 (autoload 'pr-whisper--server-path "pr-whisper-server")
@@ -390,14 +391,18 @@ shorter than `pr-whisper-history-min-length'."
 
 (defun pr-whisper-default-insert (text marker)
   "Insert TEXT at MARKER using default behavior.
-Handles vterm mode and read-only buffers."
+Handles vterm mode, ghostel mode, and read-only buffers."
   (when (marker-buffer marker)
     (with-current-buffer (marker-buffer marker)
       (condition-case nil
-          (if (eq major-mode 'vterm-mode)
-              (vterm-send-string (concat text " "))
+          (cond
+           ((eq major-mode 'vterm-mode)
+            (vterm-send-string (concat text " ")))
+           ((eq major-mode 'ghostel-mode)
+            (ghostel-send-string (concat text " ")))
+           (t
             (goto-char marker)
-            (insert text " "))
+            (insert text " ")))
         (buffer-read-only
          (message "Whisper: Buffer is read-only, text saved to history: %s"
                   (truncate-string-to-width text 50 nil nil "...")))))))


### PR DESCRIPTION
Send transcribed text to ghostel buffers via `ghostel-send-string`, mirroring the existing vterm special case.

## Changes
- `pr-whisper-default-insert` now dispatches on major mode with a `cond`: vterm, ghostel, or plain buffer insert
- Add `declare-function` for `ghostel-send-string`

ghostel buffers are rendered by a native module, so a plain `insert` at the marker has no effect; text must go through `ghostel-send-string`, same as vterm.

## Testing
- `./build` passes (byte-compile with warnings-as-errors)
- ERT tests pass (13/13)
- Manually verified transcription insertion into a live ghostel buffer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ghostel-mode to insert transcribed text into buffers, expanding compatibility beyond existing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->